### PR TITLE
fallback to openarm_driver default config

### DIFF
--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -84,7 +84,7 @@ def main():
     )
     parser.add_argument(
         "--config",
-        default="openarm_cell.yaml",
+        default=None,
         help="The configuration file for this OpenArm",
         type=pathlib.Path,
     )


### PR DESCRIPTION
openarm_driver.Config
has default config.yaml(openarm_cell.yaml in latest) and falls back to this file if `args.config` is `None`.

Default behavior should use them.
