### PR TITLE
Don't auto-start the arm; create the driver once and reuse it

### DIFF
--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -123,13 +123,15 @@ def main():
     args = parser.parse_args()
     node = dora.Node()
     name = f"{args.side}_arm"
+    status = ArmStatus.STOPPED
+    node.send_output("status", pa.array([ArmStatus.STOPPED]))
     config = openarm_driver.Config(args.config)
-    arm = openarm_driver.SingleArmDriver(name, config)
-    arm.start()
-    status = ArmStatus.STARTED
-    align_threshold = args.align_threshold
-    align_state = AlignState()
-    node.send_output("status", pa.array([ArmStatus.STARTED]))
+    #arm = openarm_driver.SingleArmDriver(name, config)
+    #arm.start()
+    #status = ArmStatus.STARTED
+    #align_threshold = args.align_threshold
+    #align_state = AlignState()
+    #node.send_output("status", pa.array([ArmStatus.STARTED]))
     for event in node:
         if event["type"] != "INPUT":
             continue

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -123,8 +123,6 @@ def main():
     args = parser.parse_args()
     node = dora.Node()
     name = f"{args.side}_arm"
-    status = ArmStatus.STOPPED
-    node.send_output("status", pa.array([ArmStatus.STOPPED]))
     config = openarm_driver.Config(args.config)
     arm = openarm_driver.SingleArmDriver(name, config)
     arm.start()

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -127,10 +127,6 @@ def main():
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
     arm = openarm_driver.SingleArmDriver(name, config)
-    # arm.start()
-    # status = ArmStatus.STARTED
-    # align_state = AlignState()
-    # node.send_output("status", pa.array([ArmStatus.STARTED]))
     for event in node:
         if event["type"] != "INPUT":
             continue

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -126,7 +126,7 @@ def main():
     node.send_output("status", pa.array([ArmStatus.STOPPED]))
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
-    # arm = openarm_driver.SingleArmDriver(name, config)
+    arm = openarm_driver.SingleArmDriver(name, config)
     # arm.start()
     # status = ArmStatus.STARTED
     # align_state = AlignState()

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -43,8 +43,7 @@ class AlignState:
 
 def _align(arm, state, new_position, name, threshold, trigger=None):
     """Safety: Align OpenArm with the position."""
-    if trigger == "gripper":
-        # Check if gripper is active (threshold ~ -10 deg)
+    if trigger == "gripper":  # Check if gripper is active (threshold ~ -10 deg)
         gripper_position = new_position[-1]  # Last value is gripper's position
         if name == "right_arm":
             is_gripping = gripper_position.as_py() > np.deg2rad(-5)
@@ -126,12 +125,12 @@ def main():
     status = ArmStatus.STOPPED
     node.send_output("status", pa.array([ArmStatus.STOPPED]))
     config = openarm_driver.Config(args.config)
-    #arm = openarm_driver.SingleArmDriver(name, config)
-    #arm.start()
-    #status = ArmStatus.STARTED
-    #align_threshold = args.align_threshold
-    #align_state = AlignState()
-    #node.send_output("status", pa.array([ArmStatus.STARTED]))
+    align_threshold = args.align_threshold
+    # arm = openarm_driver.SingleArmDriver(name, config)
+    # arm.start()
+    # status = ArmStatus.STARTED
+    # align_state = AlignState()
+    # node.send_output("status", pa.array([ArmStatus.STARTED]))
     for event in node:
         if event["type"] != "INPUT":
             continue

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -139,7 +139,6 @@ def main():
         if event_id == "command":
             command = event["value"][0].as_py()
             if command == "start":
-                arm = openarm_driver.SingleArmDriver(name, config)
                 arm.start()
                 align_state = AlignState()
                 status = ArmStatus.STARTED


### PR DESCRIPTION
# Summary
The OpenArm node no longer powers up the arm when it launches. Instead, it boots in the STOPPED state and waits for an explicit start command. The SingleArmDriver is now instantiated a single time at startup and reused across start/stop cycles rather than being re-created on every start.

# Motivation
 Previously, the node called arm.start() during initialization, so the arm went live the moment the node came up — before any operator command. This branch defers activation to the start command, giving the controller explicit ownership of when the hardware engages. Reusing one driver instance also avoids allocating a fresh SingleArmDriver on each start.

# Changes

  - Remove initial start: at startup, the node sends STOPPED status and constructs the driver, but no longer calls arm.start().
  - Reuse the driver instance: the start command handler no longer re-creates arm = SingleArmDriver(...); it calls arm.start() on the existing instance. AlignState is (re)initialized in the start handler, which is the only place it's needed.