### PR TITLE
Add `--start-on-startup` for backward compatibility 

### DIFF
--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -119,14 +119,26 @@ def main():
         default=_env_flag("REFRESH", True),
         help="Refresh OpenArm on every request to make it more accurate.",
     )
+    parser.add_argument(
+        "--initial-start",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Start the arm on startup.",
+    )
     args = parser.parse_args()
     node = dora.Node()
     name = f"{args.side}_arm"
-    status = ArmStatus.STOPPED
-    node.send_output("status", pa.array([ArmStatus.STOPPED]))
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
     arm = openarm_driver.SingleArmDriver(name, config)
+    if args.initial_start:
+        arm.start()
+        align_state = AlignState()
+        status = ArmStatus.STARTED
+        node.send_output("status", pa.array([ArmStatus.STARTED]))
+    else:
+        status = ArmStatus.STOPPED
+        node.send_output("status", pa.array([ArmStatus.STOPPED]))
     for event in node:
         if event["type"] != "INPUT":
             continue

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -120,7 +120,7 @@ def main():
         help="Refresh OpenArm on every request to make it more accurate.",
     )
     parser.add_argument(
-        "--initial-start",
+        "--start-on-startup",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Start the arm on startup.",
@@ -131,7 +131,7 @@ def main():
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
     arm = openarm_driver.SingleArmDriver(name, config)
-    if args.initial_start:
+    if args.start_on_startup:
         arm.start()
         align_state = AlignState()
         status = ArmStatus.STARTED


### PR DESCRIPTION
The default behavior should be `stopped`.
However, in some cases, we want to start the Arm without any `command`.
