### PR TITLE
added tmos and trotor (as int32 arrays) to the existing state StructArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ nodes:
 | Output | Description |
 | --- | --- |
 | `position` | Current arm position as a float32 array. |
-| `state` | Current arm state as a struct with float32 array fields `qpos`, `qvel`, and `qtorque`. |
+| `state` | Current arm state as a struct with float32 array fields `qpos`, `qvel`, and `qtorque`, plus int32 array fields `tmos` (MOS temperature) and `trotor` (rotor temperature) per motor, in °C. |
 | `status` | A string array containing `ready` once the initial alignment completes. |
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.10"
 
-dependencies = ["dora-rs >= 0.5.0", "openarm-driver"]
+dependencies = ["dora-rs >= 0.5.0", "openarm-driver >= 0.2.0"]
 
 [dependency-groups]
 dev = [

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -172,8 +172,10 @@ def main():
                         pa.array(state["qpos"], type=pa.float32()),
                         pa.array(state["qvel"], type=pa.float32()),
                         pa.array(state["qtorque"], type=pa.float32()),
+                        pa.array(state["tmos"], type=pa.int32()),
+                        pa.array(state["trotor"], type=pa.int32()),
                     ],
-                    names=["qpos", "qvel", "qtorque"],
+                    names=["qpos", "qvel", "qtorque", "tmos", "trotor"],
                 ),
             )
         elif event_id == "move_position":


### PR DESCRIPTION
Exposes per-motor temperature in the `request_state` → `state` output.
The `openarm_driver.fetch_state()` call already returns MOS and rotor
temperatures (added in openarm_driver enactic/openarm_driver#14), but the node was dropping
them. This PR surfaces them so downstream nodes can monitor thermals.

- Adds fields to an existing output without changing field order, so
  existing consumers reading `qpos`/`qvel`/`qtorque` by name are
  unaffected.