### PR TITLE
Ignore `request_position`/`request_state` in stopping state

### DIFF
--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import pyarrow as pa
 import numpy as np
-
+import time
 
 class ArmStatus(str, enum.Enum):
     """Arm control states."""
@@ -148,14 +148,16 @@ def main():
             command = event["value"][0].as_py()
             if command == "start":
                 arm.start()
+                time.sleep(0.5)  # Wait for the arm to start
                 align_state = AlignState()
                 status = ArmStatus.STARTED
-                node.send_output("status", pa.array([ArmStatus.STARTED]))
             elif command == "stop":
                 status = ArmStatus.STOPPED
                 node.send_output("status", pa.array([ArmStatus.STOPPED]))
                 arm.stop()
         elif event_id == "request_position":
+            if status is ArmStatus.STOPPED:
+                continue
             current_position = arm.fetch_position(
                 refresh=args.refresh_every_request,
             )
@@ -164,6 +166,8 @@ def main():
                 pa.array(current_position, type=pa.float32()),
             )
         elif event_id == "request_state":
+            if status is ArmStatus.STOPPED:
+                continue
             state = arm.fetch_state(refresh=args.refresh_every_request)
             node.send_output(
                 "state",

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -148,7 +148,7 @@ def main():
             command = event["value"][0].as_py()
             if command == "start":
                 arm.start()
-                time.sleep(0.5)  # Wait for the arm to start
+                time.sleep(1)  # Wait for the arm to start
                 align_state = AlignState()
                 status = ArmStatus.STARTED
             elif command == "stop":

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -149,7 +149,6 @@ def main():
             if command == "start":
                 arm = openarm_driver.SingleArmDriver(name, config) # Re-initialize the arm to ensure a fresh start
                 arm.start()
-                time.sleep(1)  # Wait for the arm to start
                 align_state = AlignState()
                 status = ArmStatus.STARTED
                 node.send_output("status", pa.array([ArmStatus.STARTED]))

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import pyarrow as pa
 import numpy as np
-import time
+
 
 class ArmStatus(str, enum.Enum):
     """Arm control states."""
@@ -147,7 +147,9 @@ def main():
         if event_id == "command":
             command = event["value"][0].as_py()
             if command == "start":
-                arm = openarm_driver.SingleArmDriver(name, config) # Re-initialize the arm to ensure a fresh start
+                arm = openarm_driver.SingleArmDriver(
+                    name, config
+                )  # Re-initialize the arm to ensure a fresh start
                 arm.start()
                 align_state = AlignState()
                 status = ArmStatus.STARTED

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -151,13 +151,13 @@ def main():
                 time.sleep(1)  # Wait for the arm to start
                 align_state = AlignState()
                 status = ArmStatus.STARTED
+                node.send_output("status", pa.array([ArmStatus.STARTED]))
             elif command == "stop":
                 status = ArmStatus.STOPPED
                 node.send_output("status", pa.array([ArmStatus.STOPPED]))
                 arm.stop()
         elif event_id == "request_position":
             if status is ArmStatus.STOPPED:
-                print("Arm is stopped, cannot fetch position.")
                 continue
             current_position = arm.fetch_position(
                 refresh=args.refresh_every_request,
@@ -168,7 +168,6 @@ def main():
             )
         elif event_id == "request_state":
             if status is ArmStatus.STOPPED:
-                print("Arm is stopped, cannot fetch state.")
                 continue
             state = arm.fetch_state(refresh=args.refresh_every_request)
             node.send_output(

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -130,6 +130,7 @@ def main():
     name = f"{args.side}_arm"
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
+    arm = None
     if args.start_on_startup:
         arm = openarm_driver.SingleArmDriver(name, config)
         arm.start()
@@ -147,6 +148,8 @@ def main():
         if event_id == "command":
             command = event["value"][0].as_py()
             if command == "start":
+                if arm is not None:
+                    arm.stop()  # Stop the existing session before replacing it
                 arm = openarm_driver.SingleArmDriver(
                     name, config
                 )  # Re-initialize the arm to ensure a fresh start
@@ -157,8 +160,9 @@ def main():
             elif command == "stop":
                 status = ArmStatus.STOPPED
                 node.send_output("status", pa.array([ArmStatus.STOPPED]))
-                arm.stop()
-                del arm  # Remove the arm instance to free resources
+                if arm is not None:
+                    arm.stop()
+                    arm = None  # Drop the instance to free resources
         elif event_id == "request_position":
             if status is ArmStatus.STOPPED:
                 continue
@@ -225,10 +229,11 @@ def main():
                 if is_aligned:
                     status = ArmStatus.ALIGNED
                     node.send_output("status", pa.array([ArmStatus.ALIGNED]))
-    if args.stop:
-        arm.stop()
-    else:
-        arm.on_start()
+    if arm is not None:
+        if args.stop:
+            arm.stop()
+        else:
+            arm.on_start()
 
 
 if __name__ == "__main__":

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -147,6 +147,7 @@ def main():
         if event_id == "command":
             command = event["value"][0].as_py()
             if command == "start":
+                arm = openarm_driver.SingleArmDriver(name, config) # Re-initialize the arm to ensure a fresh start
                 arm.start()
                 time.sleep(1)  # Wait for the arm to start
                 align_state = AlignState()

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -130,8 +130,8 @@ def main():
     name = f"{args.side}_arm"
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
-    arm = openarm_driver.SingleArmDriver(name, config)
     if args.start_on_startup:
+        arm = openarm_driver.SingleArmDriver(name, config)
         arm.start()
         align_state = AlignState()
         status = ArmStatus.STARTED
@@ -157,6 +157,7 @@ def main():
                 status = ArmStatus.STOPPED
                 node.send_output("status", pa.array([ArmStatus.STOPPED]))
                 arm.stop()
+                del arm  # Remove the arm instance to free resources
         elif event_id == "request_position":
             if status is ArmStatus.STOPPED:
                 continue

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -157,6 +157,7 @@ def main():
                 arm.stop()
         elif event_id == "request_position":
             if status is ArmStatus.STOPPED:
+                print("Arm is stopped, cannot fetch position.")
                 continue
             current_position = arm.fetch_position(
                 refresh=args.refresh_every_request,
@@ -167,6 +168,7 @@ def main():
             )
         elif event_id == "request_state":
             if status is ArmStatus.STOPPED:
+                print("Arm is stopped, cannot fetch state.")
                 continue
             state = arm.fetch_state(refresh=args.refresh_every_request)
             node.send_output(


### PR DESCRIPTION
- Don't send `position` and `state` when the arm is STOPPED.