### PR TITLE
Use the correct SingleArmDriver method

### DIFF
--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -233,7 +233,7 @@ def main():
         if args.stop:
             arm.stop()
         else:
-            arm.on_start()
+            arm.move_to_start_position()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The on_start() method does not exist and raises an error.
https://github.com/enactic/openarm_driver/blob/83d04b59faa6de8bb6943d773aa3f07b71c42137/src/openarm_driver/driver.py#L267-L268

Rename it to the correct method.