### PR TITLE
Restore one-time startup alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ nodes:
 | `--config` | Path to the OpenArm configuration file. Default: `openarm_cell.yaml`. |
 | `--align-trigger` | Optional trigger for the initial alignment step. Supported value: `gripper`. |
 | `--align-threshold` | Alignment threshold in radians. Default: `0.1`. |
+| `--align-delta-limit` | Maximum joint delta per initial-alignment command in radians. Default: `0.001`. |
+| `--[no-]align` | Whether to align to incoming position commands after the arm starts. Default: enabled. |
 | `--[no-]stop` | Whether to stop the arm when the node exits. Default: controlled by the `STOP` environment variable, or `true` when it is unset. |
 | `--[no-]refresh-every-request` | Whether to refresh OpenArm state before each request. Default: controlled by the `REFRESH` environment variable, or `true` when it is unset. |
 
@@ -54,7 +56,7 @@ nodes:
 | --- | --- |
 | `request_position` | Requests the current arm position. The event ID is used and the event value is ignored. |
 | `request_state` | Requests the current arm state. The event ID is used and the event value is ignored. |
-| `move_position` | Sends a new target position to the arm. The value may be a struct containing `qpos` (`[{"qpos": [...]}]`), a position array directly, or a legacy struct containing `new_position`. When the node has not been initialized yet, this input first drives the alignment step. |
+| `move_position` | Sends a new target position to the arm. The value may be a struct containing `qpos` (`[{"qpos": [...]}]`), a position array directly, or a legacy struct containing `new_position`. When initial alignment is enabled, this input drives the alignment until it completes. |
 
 ### Outputs
 
@@ -62,7 +64,7 @@ nodes:
 | --- | --- |
 | `position` | Current arm position as a length-1 struct containing a float32 array: `[{"qpos": [...]}]`. |
 | `state` | Current arm state as a length-1 struct with list fields: `[{"qpos": [...], "qvel": [...], "qtorque": [...], "tmos": [...], "trotor": [...]}]`. `qpos`, `qvel`, and `qtorque` are float32 lists; `tmos` (MOS temperature) and `trotor` (rotor temperature) are int32 lists per motor, in °C. |
-| `status` | A string array containing `ready` once the initial alignment completes. |
+| `status` | Current control state as a string array: `stopped`, `started`, or `aligned`. With alignment enabled, `aligned` is emitted once initial alignment completes. |
 
 ## License
 

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -214,7 +214,9 @@ def main():
                 )  # Re-initialize the arm to ensure a fresh start
                 arm.start()
                 align_state = (
-                    AlignState(step_limit=args.align_delta_limit) if args.align else None
+                    AlignState(step_limit=args.align_delta_limit)
+                    if args.align
+                    else None
                 )
                 status = ArmStatus.STARTED
                 node.send_output("status", pa.array([status]))
@@ -270,6 +272,7 @@ def main():
                     trigger=args.align_trigger,
                 )
                 if is_aligned:
+                    arm.send_position(new_position)
                     status = ArmStatus.ALIGNED
                     node.send_output("status", pa.array([ArmStatus.ALIGNED]))
     if arm is not None:

--- a/src/dora_openarm/main.py
+++ b/src/dora_openarm/main.py
@@ -52,17 +52,16 @@ def _align(arm, state, new_position, name, threshold, trigger=None):
         if not is_gripping:
             return False
 
-    def current_position():
-        return np.array(arm.fetch_position(), dtype=np.float32)
+    current_position = np.array(arm.fetch_position(), dtype=np.float32)
 
     if state.align_target is None:
-        state.align_target = current_position()
+        state.align_target = current_position.copy()
 
     def is_aligned(position1, position2):
-        return np.all(np.abs(position1 - position2) < threshold)
+        return np.all(np.abs(position1[:-1] - position2[:-1]) < threshold)
 
     # If OpenArm is already aligned, we do nothing.
-    if is_aligned(new_position, current_position()):
+    if is_aligned(new_position, current_position):
         return True
     diff = new_position - state.align_target
     step_move = np.clip(diff, -state.step_limit, state.step_limit)
@@ -70,7 +69,8 @@ def _align(arm, state, new_position, name, threshold, trigger=None):
 
     arm.send_position(state.align_target)
 
-    return is_aligned(new_position, current_position())
+    # Check the physical position on the next command after the arm has moved.
+    return False
 
 
 def _env_flag(name, default=False):
@@ -149,6 +149,18 @@ def main():
         type=float,
     )
     parser.add_argument(
+        "--align-delta-limit",
+        default=0.001,
+        help="Maximum joint delta per alignment command [rad] (default: 0.001).",
+        type=float,
+    )
+    parser.add_argument(
+        "--align",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Align to incoming position commands after start (default: enabled).",
+    )
+    parser.add_argument(
         "--stop",
         action=argparse.BooleanOptionalAction,
         default=_env_flag("STOP", True),
@@ -167,18 +179,24 @@ def main():
         help="Start the arm on startup.",
     )
     args = parser.parse_args()
+    if args.align_delta_limit <= 0.0:
+        parser.error("--align-delta-limit must be positive")
     node = dora.Node()
     name = f"{args.side}_arm"
     config = openarm_driver.Config(args.config)
     align_threshold = args.align_threshold
     arm = None
+    ready_status = ArmStatus.ALIGNED if args.align else ArmStatus.STARTED
     if args.start_on_startup:
         arm = openarm_driver.SingleArmDriver(name, config)
         arm.start()
-        align_state = AlignState()
+        align_state = (
+            AlignState(step_limit=args.align_delta_limit) if args.align else None
+        )
         status = ArmStatus.STARTED
-        node.send_output("status", pa.array([ArmStatus.STARTED]))
+        node.send_output("status", pa.array([status]))
     else:
+        align_state = None
         status = ArmStatus.STOPPED
         node.send_output("status", pa.array([ArmStatus.STOPPED]))
     for event in node:
@@ -195,15 +213,18 @@ def main():
                     name, config
                 )  # Re-initialize the arm to ensure a fresh start
                 arm.start()
-                align_state = AlignState()
+                align_state = (
+                    AlignState(step_limit=args.align_delta_limit) if args.align else None
+                )
                 status = ArmStatus.STARTED
-                node.send_output("status", pa.array([ArmStatus.STARTED]))
+                node.send_output("status", pa.array([status]))
             elif command == "stop":
                 status = ArmStatus.STOPPED
                 node.send_output("status", pa.array([ArmStatus.STOPPED]))
                 if arm is not None:
                     arm.stop()
                     arm = None  # Drop the instance to free resources
+                align_state = None
         elif event_id == "request_position":
             if status is ArmStatus.STOPPED:
                 continue
@@ -237,18 +258,9 @@ def main():
                 new_position = np.array(value, dtype=np.float32)
                 # other_arm_position = None
 
-            if status is ArmStatus.ALIGNED:
-                diverged = np.any(
-                    np.abs(new_position[:-1] - arm.last_command[:-1]) > align_threshold
-                )
-                if diverged:
-                    status = ArmStatus.STARTED
-                    align_state = AlignState()
-                    node.send_output("status", pa.array([ArmStatus.STARTED]))
-                else:
-                    arm.send_position(new_position)
-
-            if status is ArmStatus.STARTED:
+            if status is ready_status:
+                arm.send_position(new_position)
+            elif status is ArmStatus.STARTED:
                 is_aligned = _align(
                     arm,
                     align_state,


### PR DESCRIPTION
## Summary

- Run alignment once after arm startup instead of re-entering it during normal control.
- Add `--[no-]align` and `--align-delta-limit`.
- Fetch arm position once per alignment command and exclude the gripper from the completion check.
- Document alignment behavior and status outputs.

Runtime command limiting remains the driver's responsibility for now. A dedicated runtime limiter can be added separately.

The real-time alignment function will cause unstable behavior.